### PR TITLE
Rename yoyo tweening to ping-pong and refactor structs

### DIFF
--- a/Source/NsTween/Private/Blueprints/NsTweenAsyncAction.cpp
+++ b/Source/NsTween/Private/Blueprints/NsTweenAsyncAction.cpp
@@ -42,8 +42,8 @@ void UNsTweenAsyncAction::Activate()
     TweenInstance->SetDelay(Delay)
                  ->SetLoops(Loops)
                  ->SetLoopDelay(LoopDelay)
-                 ->SetYoyo(bYoyo)
-                 ->SetYoyoDelay(YoyoDelay)
+                 ->SetPingPong(bPingPong)
+                 ->SetPingPongDelay(PingPongDelay)
                  ->SetCanTickDuringPause(bCanTickDuringPause)
                  ->SetUseGlobalTimeDilation(bUseGlobalTimeDilation)
                  // we will tell it when to be destroyed on complete, so that we control when
@@ -56,9 +56,9 @@ void UNsTweenAsyncAction::Activate()
     {
         TweenInstance->SetOnLoop([&]() { OnLoop.Broadcast(); });
     }
-    if (OnYoyo.IsBound())
+    if (OnPingPong.IsBound())
     {
-        TweenInstance->SetOnYoyo([&]() { OnYoyo.Broadcast(); });
+        TweenInstance->SetOnPingPong([&]() { OnPingPong.Broadcast(); });
     }
     if (OnComplete.IsBound())
     {
@@ -81,7 +81,7 @@ NsTweenInstance* UNsTweenAsyncAction::CreateTweenCustomCurve()
     return nullptr;
 }
 
-void UNsTweenAsyncAction::SetSharedTweenProperties(float InDurationSecs, float InDelay, int InLoops, float InLoopDelay, bool InbYoyo, float InYoyoDelay, bool bInCanTickDuringPause, bool bInUseGlobalTimeDilation)
+void UNsTweenAsyncAction::SetSharedTweenProperties(float InDurationSecs, float InDelay, int InLoops, float InLoopDelay, bool InbPingPong, float InPingPongDelay, bool bInCanTickDuringPause, bool bInUseGlobalTimeDilation)
 {
     TweenInstance = nullptr;
     bUseCustomCurve = false;
@@ -90,8 +90,8 @@ void UNsTweenAsyncAction::SetSharedTweenProperties(float InDurationSecs, float I
     Delay = InDelay;
     Loops = InLoops;
     LoopDelay = InLoopDelay;
-    bYoyo = InbYoyo;
-    YoyoDelay = InYoyoDelay;
+    bPingPong = InbPingPong;
+    PingPongDelay = InPingPongDelay;
     bCanTickDuringPause = bInCanTickDuringPause;
     bUseGlobalTimeDilation = bInUseGlobalTimeDilation;
 }
@@ -153,10 +153,10 @@ void UNsTweenAsyncAction::SetTimeMultiplier(float Multiplier)
     }
 }
 
-UNsTweenAsyncActionFloat* UNsTweenAsyncActionFloat::TweenFloat(float Start, float End, float DurationSecs, ENsTweenEase EaseType, float EaseParam1, float EaseParam2, float Delay, int Loops, float LoopDelay, bool bYoyo, float YoyoDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
+UNsTweenAsyncActionFloat* UNsTweenAsyncActionFloat::TweenFloat(float Start, float End, float DurationSecs, ENsTweenEase EaseType, float EaseParam1, float EaseParam2, float Delay, int Loops, float LoopDelay, bool bPingPong, float PingPongDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
 {
     UNsTweenAsyncActionFloat* BlueprintNode = NewObject<UNsTweenAsyncActionFloat>();
-    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bYoyo, YoyoDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
+    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bPingPong, PingPongDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
     BlueprintNode->EaseType = EaseType;
     BlueprintNode->Start = Start;
     BlueprintNode->End = End;
@@ -165,10 +165,10 @@ UNsTweenAsyncActionFloat* UNsTweenAsyncActionFloat::TweenFloat(float Start, floa
     return BlueprintNode;
 }
 
-UNsTweenAsyncActionFloat* UNsTweenAsyncActionFloat::TweenFloatCustomCurve(float Start, float End, float DurationSecs, UCurveFloat* Curve, float Delay, int Loops, float LoopDelay, bool bYoyo, float YoyoDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
+UNsTweenAsyncActionFloat* UNsTweenAsyncActionFloat::TweenFloatCustomCurve(float Start, float End, float DurationSecs, UCurveFloat* Curve, float Delay, int Loops, float LoopDelay, bool bPingPong, float PingPongDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
 {
     UNsTweenAsyncActionFloat* BlueprintNode = NewObject<UNsTweenAsyncActionFloat>();
-    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bYoyo, YoyoDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
+    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bPingPong, PingPongDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
     BlueprintNode->CustomCurve = Curve;
     BlueprintNode->bUseCustomCurve = true;
     BlueprintNode->Start = Start;
@@ -190,10 +190,10 @@ NsTweenInstance* UNsTweenAsyncActionFloat::CreateTweenCustomCurve()
         [&](float V) { ApplyEasing.Broadcast(V); });
 }
 
-UNsTweenAsyncActionQuat* UNsTweenAsyncActionQuat::TweenQuat(FQuat Start, FQuat End, float DurationSecs, ENsTweenEase EaseType, float EaseParam1, float EaseParam2, float Delay, int Loops, float LoopDelay, bool bYoyo, float YoyoDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
+UNsTweenAsyncActionQuat* UNsTweenAsyncActionQuat::TweenQuat(FQuat Start, FQuat End, float DurationSecs, ENsTweenEase EaseType, float EaseParam1, float EaseParam2, float Delay, int Loops, float LoopDelay, bool bPingPong, float PingPongDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
 {
     UNsTweenAsyncActionQuat* BlueprintNode = NewObject<UNsTweenAsyncActionQuat>();
-    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bYoyo, YoyoDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
+    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bPingPong, PingPongDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
     BlueprintNode->EaseType = EaseType;
     BlueprintNode->Start = Start;
     BlueprintNode->End = End;
@@ -202,7 +202,7 @@ UNsTweenAsyncActionQuat* UNsTweenAsyncActionQuat::TweenQuat(FQuat Start, FQuat E
     return BlueprintNode;
 }
 
-UNsTweenAsyncActionQuat* UNsTweenAsyncActionQuat::TweenQuatFromRotator(FRotator Start, FRotator End, float DurationSecs, ENsTweenEase EaseType, float EaseParam1, float EaseParam2, float Delay, int Loops, float LoopDelay, bool bYoyo, float YoyoDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
+UNsTweenAsyncActionQuat* UNsTweenAsyncActionQuat::TweenQuatFromRotator(FRotator Start, FRotator End, float DurationSecs, ENsTweenEase EaseType, float EaseParam1, float EaseParam2, float Delay, int Loops, float LoopDelay, bool bPingPong, float PingPongDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
 {
     UNsTweenAsyncActionQuat* BlueprintNode = NewObject<UNsTweenAsyncActionQuat>();
     BlueprintNode->SetSharedTweenProperties
@@ -211,8 +211,8 @@ UNsTweenAsyncActionQuat* UNsTweenAsyncActionQuat::TweenQuatFromRotator(FRotator 
              Delay,
              Loops,
              LoopDelay,
-             bYoyo,
-             YoyoDelay,
+             bPingPong,
+             PingPongDelay,
              bCanTickDuringPause,
              bUseGlobalTimeDilation
             );
@@ -224,10 +224,10 @@ UNsTweenAsyncActionQuat* UNsTweenAsyncActionQuat::TweenQuatFromRotator(FRotator 
     return BlueprintNode;
 }
 
-UNsTweenAsyncActionQuat* UNsTweenAsyncActionQuat::TweenQuatCustomCurve(FQuat Start, FQuat End, float DurationSecs, UCurveFloat* Curve, float Delay, int Loops, float LoopDelay, bool bYoyo, float YoyoDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
+UNsTweenAsyncActionQuat* UNsTweenAsyncActionQuat::TweenQuatCustomCurve(FQuat Start, FQuat End, float DurationSecs, UCurveFloat* Curve, float Delay, int Loops, float LoopDelay, bool bPingPong, float PingPongDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
 {
     UNsTweenAsyncActionQuat* BlueprintNode = NewObject<UNsTweenAsyncActionQuat>();
-    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bYoyo, YoyoDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
+    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bPingPong, PingPongDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
     BlueprintNode->CustomCurve = Curve;
     BlueprintNode->bUseCustomCurve = true;
     BlueprintNode->Start = Start;
@@ -237,10 +237,10 @@ UNsTweenAsyncActionQuat* UNsTweenAsyncActionQuat::TweenQuatCustomCurve(FQuat Sta
     return BlueprintNode;
 }
 
-UNsTweenAsyncActionQuat* UNsTweenAsyncActionQuat::TweenQuatFromRotatorCustomCurve(FRotator Start, FRotator End, float DurationSecs, UCurveFloat* Curve, float Delay, int Loops, float LoopDelay, bool bYoyo, float YoyoDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
+UNsTweenAsyncActionQuat* UNsTweenAsyncActionQuat::TweenQuatFromRotatorCustomCurve(FRotator Start, FRotator End, float DurationSecs, UCurveFloat* Curve, float Delay, int Loops, float LoopDelay, bool bPingPong, float PingPongDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
 {
     UNsTweenAsyncActionQuat* BlueprintNode = NewObject<UNsTweenAsyncActionQuat>();
-    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bYoyo, YoyoDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
+    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bPingPong, PingPongDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
     BlueprintNode->CustomCurve = Curve;
     BlueprintNode->bUseCustomCurve = true;
     BlueprintNode->Start = Start.Quaternion();
@@ -262,10 +262,10 @@ NsTweenInstance* UNsTweenAsyncActionQuat::CreateTweenCustomCurve()
         [&](const FQuat& Q) { ApplyEasing.Broadcast(Q); });
 }
 
-UNsTweenAsyncActionRotator* UNsTweenAsyncActionRotator::TweenRotator(FRotator Start, FRotator End, float DurationSecs, ENsTweenEase EaseType, float EaseParam1, float EaseParam2, float Delay, int Loops, float LoopDelay, bool bYoyo, float YoyoDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
+UNsTweenAsyncActionRotator* UNsTweenAsyncActionRotator::TweenRotator(FRotator Start, FRotator End, float DurationSecs, ENsTweenEase EaseType, float EaseParam1, float EaseParam2, float Delay, int Loops, float LoopDelay, bool bPingPong, float PingPongDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
 {
     UNsTweenAsyncActionRotator* BlueprintNode = NewObject<UNsTweenAsyncActionRotator>();
-    BlueprintNode->SetSharedTweenProperties (  DurationSecs,  Delay,  Loops,  LoopDelay,  bYoyo,  YoyoDelay,  bCanTickDuringPause,  bUseGlobalTimeDilation );
+    BlueprintNode->SetSharedTweenProperties (  DurationSecs,  Delay,  Loops,  LoopDelay,  bPingPong,  PingPongDelay,  bCanTickDuringPause,  bUseGlobalTimeDilation );
     BlueprintNode->EaseType = EaseType;
     BlueprintNode->Start = Start.Quaternion();
     BlueprintNode->End = End.Quaternion();
@@ -274,10 +274,10 @@ UNsTweenAsyncActionRotator* UNsTweenAsyncActionRotator::TweenRotator(FRotator St
     return BlueprintNode;
 }
 
-UNsTweenAsyncActionRotator* UNsTweenAsyncActionRotator::TweenRotatorCustomCurve(FRotator Start, FRotator End, float DurationSecs, UCurveFloat* Curve, float Delay, int Loops, float LoopDelay, bool bYoyo, float YoyoDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
+UNsTweenAsyncActionRotator* UNsTweenAsyncActionRotator::TweenRotatorCustomCurve(FRotator Start, FRotator End, float DurationSecs, UCurveFloat* Curve, float Delay, int Loops, float LoopDelay, bool bPingPong, float PingPongDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
 {
     UNsTweenAsyncActionRotator* BlueprintNode = NewObject<UNsTweenAsyncActionRotator>();
-    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bYoyo, YoyoDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
+    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bPingPong, PingPongDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
     BlueprintNode->CustomCurve = Curve;
     BlueprintNode->bUseCustomCurve = true;
     BlueprintNode->Start = Start.Quaternion();
@@ -305,10 +305,10 @@ NsTweenInstance* UNsTweenAsyncActionRotator::CreateTweenCustomCurve()
         });
 }
 
-UNsTweenAsyncActionVector* UNsTweenAsyncActionVector::TweenVector(FVector Start, FVector End, float DurationSecs, ENsTweenEase EaseType, float EaseParam1, float EaseParam2, float Delay, int Loops, float LoopDelay, bool bYoyo, float YoyoDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
+UNsTweenAsyncActionVector* UNsTweenAsyncActionVector::TweenVector(FVector Start, FVector End, float DurationSecs, ENsTweenEase EaseType, float EaseParam1, float EaseParam2, float Delay, int Loops, float LoopDelay, bool bPingPong, float PingPongDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
 {
     UNsTweenAsyncActionVector* BlueprintNode = NewObject<UNsTweenAsyncActionVector>();
-    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bYoyo, YoyoDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
+    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bPingPong, PingPongDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
     BlueprintNode->EaseType = EaseType;
     BlueprintNode->Start = Start;
     BlueprintNode->End = End;
@@ -317,10 +317,10 @@ UNsTweenAsyncActionVector* UNsTweenAsyncActionVector::TweenVector(FVector Start,
     return BlueprintNode;
 }
 
-UNsTweenAsyncActionVector* UNsTweenAsyncActionVector::TweenVectorCustomCurve(FVector Start, FVector End, float DurationSecs, UCurveFloat* Curve, float Delay, int Loops, float LoopDelay, bool bYoyo, float YoyoDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
+UNsTweenAsyncActionVector* UNsTweenAsyncActionVector::TweenVectorCustomCurve(FVector Start, FVector End, float DurationSecs, UCurveFloat* Curve, float Delay, int Loops, float LoopDelay, bool bPingPong, float PingPongDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
 {
     UNsTweenAsyncActionVector* BlueprintNode = NewObject<UNsTweenAsyncActionVector>();
-    BlueprintNode->SetSharedTweenProperties(  DurationSecs,  Delay,  Loops,  LoopDelay,  bYoyo,  YoyoDelay,  bCanTickDuringPause,  bUseGlobalTimeDilation );
+    BlueprintNode->SetSharedTweenProperties(  DurationSecs,  Delay,  Loops,  LoopDelay,  bPingPong,  PingPongDelay,  bCanTickDuringPause,  bUseGlobalTimeDilation );
     BlueprintNode->CustomCurve = Curve;
     BlueprintNode->bUseCustomCurve = true;
     BlueprintNode->Start = Start;
@@ -342,10 +342,10 @@ NsTweenInstance* UNsTweenAsyncActionVector::CreateTweenCustomCurve()
         [&](const FVector& V) { ApplyEasing.Broadcast(V); });
 }
 
-UNsTweenAsyncActionVector2D* UNsTweenAsyncActionVector2D::TweenVector2D(FVector2D Start, FVector2D End, float DurationSecs, ENsTweenEase EaseType, float EaseParam1, float EaseParam2, float Delay, int Loops, float LoopDelay, bool bYoyo, float YoyoDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
+UNsTweenAsyncActionVector2D* UNsTweenAsyncActionVector2D::TweenVector2D(FVector2D Start, FVector2D End, float DurationSecs, ENsTweenEase EaseType, float EaseParam1, float EaseParam2, float Delay, int Loops, float LoopDelay, bool bPingPong, float PingPongDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
 {
     UNsTweenAsyncActionVector2D* BlueprintNode = NewObject<UNsTweenAsyncActionVector2D>();
-    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bYoyo, YoyoDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
+    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bPingPong, PingPongDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
     BlueprintNode->EaseType = EaseType;
     BlueprintNode->Start = Start;
     BlueprintNode->End = End;
@@ -354,10 +354,10 @@ UNsTweenAsyncActionVector2D* UNsTweenAsyncActionVector2D::TweenVector2D(FVector2
     return BlueprintNode;
 }
 
-UNsTweenAsyncActionVector2D* UNsTweenAsyncActionVector2D::TweenVector2DCustomCurve(FVector2D Start, FVector2D End, float DurationSecs, UCurveFloat* Curve, float Delay, int Loops, float LoopDelay, bool bYoyo, float YoyoDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
+UNsTweenAsyncActionVector2D* UNsTweenAsyncActionVector2D::TweenVector2DCustomCurve(FVector2D Start, FVector2D End, float DurationSecs, UCurveFloat* Curve, float Delay, int Loops, float LoopDelay, bool bPingPong, float PingPongDelay, bool bCanTickDuringPause, bool bUseGlobalTimeDilation)
 {
     UNsTweenAsyncActionVector2D* BlueprintNode = NewObject<UNsTweenAsyncActionVector2D>();
-    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bYoyo, YoyoDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
+    BlueprintNode->SetSharedTweenProperties( DurationSecs, Delay, Loops, LoopDelay, bPingPong, PingPongDelay, bCanTickDuringPause, bUseGlobalTimeDilation);
     BlueprintNode->CustomCurve = Curve;
     BlueprintNode->bUseCustomCurve = true;
     BlueprintNode->Start = Start;

--- a/Source/NsTween/Private/Classes/NsTweenUObject.cpp
+++ b/Source/NsTween/Private/Classes/NsTweenUObject.cpp
@@ -4,29 +4,31 @@
 #include "Classes/NsTweenInstance.h"
 
 UNsTweenUObject::UNsTweenUObject()
-{
-	Tween = nullptr;
-}
+    : Tween(nullptr)
+{}
 void UNsTweenUObject::BeginDestroy()
 {
-	if (Tween != nullptr)
-	{
-		Tween->Destroy();
-		Tween = nullptr;
-	}
-	UObject::BeginDestroy();
+    if (Tween)
+    {
+        // Clean up the managed tween before destruction
+        Tween->Destroy();
+        Tween = nullptr;
+    }
+    Super::BeginDestroy();
 }
-
 void UNsTweenUObject::SetTweenInstance(NsTweenInstance* InTween)
 {
-	this->Tween = InTween;
-	// destroy when we are destroyed
-	this->Tween->SetAutoDestroy(false);
+    Tween = InTween;
+    // Prevent the tween from destroying itself prematurely
+    Tween->SetAutoDestroy(false);
 }
 
 void UNsTweenUObject::Destroy()
 {
-	this->Tween->Destroy();
-	this->Tween = nullptr;
-	ConditionalBeginDestroy();
+    if (Tween)
+    {
+        Tween->Destroy();
+        Tween = nullptr;
+    }
+    ConditionalBeginDestroy();
 }

--- a/Source/NsTween/Public/Blueprints/NsTweenAsyncAction.h
+++ b/Source/NsTween/Public/Blueprints/NsTweenAsyncAction.h
@@ -32,7 +32,7 @@ public:
     virtual class NsTweenInstance* CreateTweenCustomCurve();
 
     /** Set shared tween properties */
-    virtual void SetSharedTweenProperties(float InDurationSecs, float InDelay, int InLoops, float InLoopDelay, bool InbYoyo, float InYoyoDelay, bool bInCanTickDuringPause, bool bInUseGlobalTimeDilation);
+    virtual void SetSharedTweenProperties(float InDurationSecs, float InDelay, int InLoops, float InLoopDelay, bool InbPingPong, float InPingPongDelay, bool bInCanTickDuringPause, bool bInUseGlobalTimeDilation);
 
     /** Begin Destroy */
     virtual void BeginDestroy() override;
@@ -75,11 +75,11 @@ public:
     /** Loop delay */
     float LoopDelay;
 
-    /** YoYo */
-    bool bYoyo;
+    /** PingPong */
+    bool bPingPong;
 
-    /** YoYo delay */
-    float YoyoDelay;
+    /** PingPong delay */
+    float PingPongDelay;
 
     /** Can tick during pause */
     bool bCanTickDuringPause;
@@ -107,9 +107,9 @@ public:
     UPROPERTY(BlueprintAssignable, AdvancedDisplay)
     FTweenEventOutputPin OnLoop;
 
-    /** On YoYo */
+    /** On PingPong */
     UPROPERTY(BlueprintAssignable, AdvancedDisplay)
-    FTweenEventOutputPin OnYoyo;
+    FTweenEventOutputPin OnPingPong;
 
     /** On Complete */
     UPROPERTY(BlueprintAssignable, AdvancedDisplay)
@@ -145,12 +145,12 @@ public:
      * @param Delay Seconds before the tween starts interpolating, after being created
      * @param Loops The number of loops to play. -1 for infinite
      * @param LoopDelay Seconds to pause before starting each loop
-     * @param bYoyo Whether to "yoyo" the tween - once it reaches the end, it starts counting backwards
-     * @param YoyoDelay Seconds to pause before starting to yoyo
+     * @param bPingPong Whether to "pingpong" the tween - once it reaches the end, it starts counting backwards
+     * @param PingPongDelay Seconds to pause before starting to pingpong
      * @param bCanTickDuringPause Whether to play this tween while the game is paused. Useful for UI purposes, such as a pause menu
      */
     UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", AdvancedDisplay = "4"), Category = "Tween")
-    static UNsTweenAsyncActionFloat* TweenFloat(float Start = 0.0f, float End = 1.0f, float DurationSecs = 1.0f, ENsTweenEase EaseType = ENsTweenEase::InOutQuad, float EaseParam1 = 0, float EaseParam2 = 0, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bYoyo = false, float YoyoDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
+    static UNsTweenAsyncActionFloat* TweenFloat(float Start = 0.0f, float End = 1.0f, float DurationSecs = 1.0f, ENsTweenEase EaseType = ENsTweenEase::InOutQuad, float EaseParam1 = 0, float EaseParam2 = 0, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bPingPong = false, float PingPongDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
 
     /**
      * @brief Tween a float parameter between the given values
@@ -161,12 +161,12 @@ public:
      * @param Delay Seconds before the tween starts interpolating, after being created
      * @param Loops The number of loops to play. -1 for infinite
      * @param LoopDelay Seconds to pause before starting each loop
-     * @param bYoyo Whether to "yoyo" the tween - once it reaches the end, it starts counting backwards
-     * @param YoyoDelay Seconds to pause before starting to yoyo
+     * @param bPingPong Whether to "pingpong" the tween - once it reaches the end, it starts counting backwards
+     * @param PingPongDelay Seconds to pause before starting to pingpong
      * @param bCanTickDuringPause Whether to play this tween while the game is paused. Useful for UI purposes, such as a pause menu
      */
     UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", AdvancedDisplay = "4"), Category = "Tween|Custom Curve")
-    static UNsTweenAsyncActionFloat* TweenFloatCustomCurve(float Start = 0.0f, float End = 1.0f, float DurationSecs = 1.0f, UCurveFloat* Curve = nullptr, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bYoyo = false, float YoyoDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
+    static UNsTweenAsyncActionFloat* TweenFloatCustomCurve(float Start = 0.0f, float End = 1.0f, float DurationSecs = 1.0f, UCurveFloat* Curve = nullptr, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bPingPong = false, float PingPongDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
 
     //~ Begin UNsTweenAsyncAction Interface
     virtual NsTweenInstance* CreateTween() override;
@@ -207,12 +207,12 @@ public:
      * @param Delay Seconds before the tween starts interpolating, after being created
      * @param Loops The number of loops to play. -1 for infinite
      * @param LoopDelay Seconds to pause before starting each loop
-     * @param bYoyo Whether to "yoyo" the tween - once it reaches the end, it starts counting backwards
-     * @param YoyoDelay Seconds to pause before starting to yoyo
+     * @param bPingPong Whether to "pingpong" the tween - once it reaches the end, it starts counting backwards
+     * @param PingPongDelay Seconds to pause before starting to pingpong
      * @param bCanTickDuringPause Whether to play this tween while the game is paused. Useful for UI purposes, such as a pause menu
      */
     UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", AdvancedDisplay = "4"), Category = "Tween")
-    static UNsTweenAsyncActionQuat* TweenQuat(FQuat Start, FQuat End, float DurationSecs = 1.0f, ENsTweenEase EaseType = ENsTweenEase::InOutQuad, float EaseParam1 = 0, float EaseParam2 = 0, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bYoyo = false, float YoyoDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
+    static UNsTweenAsyncActionQuat* TweenQuat(FQuat Start, FQuat End, float DurationSecs = 1.0f, ENsTweenEase EaseType = ENsTweenEase::InOutQuad, float EaseParam1 = 0, float EaseParam2 = 0, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bPingPong = false, float PingPongDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
 
     /**
      * @brief Tweens a quaternion, but you can enter in yaw/pitch/roll as the input
@@ -225,12 +225,12 @@ public:
      * @param Delay Seconds before the tween starts interpolating, after being created
      * @param Loops The number of loops to play. -1 for infinite
      * @param LoopDelay Seconds to pause before starting each loop
-     * @param bYoyo Whether to "yoyo" the tween - once it reaches the end, it starts counting backwards
-     * @param YoyoDelay Seconds to pause before starting to yoyo
+     * @param bPingPong Whether to "pingpong" the tween - once it reaches the end, it starts counting backwards
+     * @param PingPongDelay Seconds to pause before starting to pingpong
      * @param bCanTickDuringPause Whether to play this tween while the game is paused. Useful for UI purposes, such as a pause menu
      */
     UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", AdvancedDisplay = "4"), Category = "Tween")
-    static UNsTweenAsyncActionQuat* TweenQuatFromRotator(FRotator Start = FRotator::ZeroRotator, FRotator End = FRotator::ZeroRotator, float DurationSecs = 1.0f, ENsTweenEase EaseType = ENsTweenEase::InOutQuad, float EaseParam1 = 0, float EaseParam2 = 0, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bYoyo = false, float YoyoDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
+    static UNsTweenAsyncActionQuat* TweenQuatFromRotator(FRotator Start = FRotator::ZeroRotator, FRotator End = FRotator::ZeroRotator, float DurationSecs = 1.0f, ENsTweenEase EaseType = ENsTweenEase::InOutQuad, float EaseParam1 = 0, float EaseParam2 = 0, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bPingPong = false, float PingPongDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
 
     /**
      * @brief Tween a float parameter between the given values
@@ -241,12 +241,12 @@ public:
      * @param Delay Seconds before the tween starts interpolating, after being created
      * @param Loops The number of loops to play. -1 for infinite
      * @param LoopDelay Seconds to pause before starting each loop
-     * @param bYoyo Whether to "yoyo" the tween - once it reaches the end, it starts counting backwards
-     * @param YoyoDelay Seconds to pause before starting to yoyo
+     * @param bPingPong Whether to "pingpong" the tween - once it reaches the end, it starts counting backwards
+     * @param PingPongDelay Seconds to pause before starting to pingpong
      * @param bCanTickDuringPause Whether to play this tween while the game is paused. Useful for UI purposes, such as a pause menu
      */
     UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", AdvancedDisplay = "4"), Category = "Tween|Custom Curve")
-    static UNsTweenAsyncActionQuat* TweenQuatCustomCurve(FQuat Start, FQuat End, float DurationSecs = 1.0f, UCurveFloat* Curve = nullptr, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bYoyo = false, float YoyoDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
+    static UNsTweenAsyncActionQuat* TweenQuatCustomCurve(FQuat Start, FQuat End, float DurationSecs = 1.0f, UCurveFloat* Curve = nullptr, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bPingPong = false, float PingPongDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
 
     /**
      * @brief Tween a float parameter between the given values
@@ -257,12 +257,12 @@ public:
      * @param Delay Seconds before the tween starts interpolating, after being created
      * @param Loops The number of loops to play. -1 for infinite
      * @param LoopDelay Seconds to pause before starting each loop
-     * @param bYoyo Whether to "yoyo" the tween - once it reaches the end, it starts counting backwards
-     * @param YoyoDelay Seconds to pause before starting to yoyo
+     * @param bPingPong Whether to "pingpong" the tween - once it reaches the end, it starts counting backwards
+     * @param PingPongDelay Seconds to pause before starting to pingpong
      * @param bCanTickDuringPause Whether to play this tween while the game is paused. Useful for UI purposes, such as a pause menu
      */
     UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", AdvancedDisplay = "4"), Category = "Tween|Custom Curve")
-    static UNsTweenAsyncActionQuat* TweenQuatFromRotatorCustomCurve(FRotator Start = FRotator::ZeroRotator, FRotator End = FRotator::ZeroRotator, float DurationSecs = 1.0f, UCurveFloat* Curve = nullptr, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bYoyo = false, float YoyoDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
+    static UNsTweenAsyncActionQuat* TweenQuatFromRotatorCustomCurve(FRotator Start = FRotator::ZeroRotator, FRotator End = FRotator::ZeroRotator, float DurationSecs = 1.0f, UCurveFloat* Curve = nullptr, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bPingPong = false, float PingPongDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
 
     //~ Begin UNsTweenAsyncAction Interface
     virtual NsTweenInstance* CreateTween() override;
@@ -299,12 +299,12 @@ public:
      * @param Delay Seconds before the tween starts interpolating, after being created
      * @param Loops The number of loops to play. -1 for infinite
      * @param LoopDelay Seconds to pause before starting each loop
-     * @param bYoyo Whether to "yoyo" the tween - once it reaches the end, it starts counting backwards
-     * @param YoyoDelay Seconds to pause before starting to yoyo
+     * @param bPingPong Whether to "pingpong" the tween - once it reaches the end, it starts counting backwards
+     * @param PingPongDelay Seconds to pause before starting to pingpong
      * @param bCanTickDuringPause Whether to play this tween while the game is paused. Useful for UI purposes, such as a pause menu
      */
     UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", AdvancedDisplay = "4"), Category = "Tween")
-    static UNsTweenAsyncActionRotator* TweenRotator(FRotator Start = FRotator::ZeroRotator, FRotator End = FRotator::ZeroRotator, float DurationSecs = 1.0f, ENsTweenEase EaseType = ENsTweenEase::InOutQuad, float EaseParam1 = 0, float EaseParam2 = 0, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bYoyo = false, float YoyoDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
+    static UNsTweenAsyncActionRotator* TweenRotator(FRotator Start = FRotator::ZeroRotator, FRotator End = FRotator::ZeroRotator, float DurationSecs = 1.0f, ENsTweenEase EaseType = ENsTweenEase::InOutQuad, float EaseParam1 = 0, float EaseParam2 = 0, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bPingPong = false, float PingPongDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
     /**
      * @brief Tween a float parameter between the given values
      * @param Start The starting value
@@ -314,12 +314,12 @@ public:
      * @param Delay Seconds before the tween starts interpolating, after being created
      * @param Loops The number of loops to play. -1 for infinite
      * @param LoopDelay Seconds to pause before starting each loop
-     * @param bYoyo Whether to "yoyo" the tween - once it reaches the end, it starts counting backwards
-     * @param YoyoDelay Seconds to pause before starting to yoyo
+     * @param bPingPong Whether to "pingpong" the tween - once it reaches the end, it starts counting backwards
+     * @param PingPongDelay Seconds to pause before starting to pingpong
      * @param bCanTickDuringPause Whether to play this tween while the game is paused. Useful for UI purposes, such as a pause menu
      */
     UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", AdvancedDisplay = "4"), Category = "Tween|Custom Curve")
-    static UNsTweenAsyncActionRotator* TweenRotatorCustomCurve(FRotator Start = FRotator::ZeroRotator, FRotator End = FRotator::ZeroRotator, float DurationSecs = 1.0f, UCurveFloat* Curve = nullptr, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bYoyo = false, float YoyoDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
+    static UNsTweenAsyncActionRotator* TweenRotatorCustomCurve(FRotator Start = FRotator::ZeroRotator, FRotator End = FRotator::ZeroRotator, float DurationSecs = 1.0f, UCurveFloat* Curve = nullptr, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bPingPong = false, float PingPongDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
 
     //~ Begin UNsTweenAsyncAction Interface
     virtual NsTweenInstance* CreateTween() override;
@@ -359,12 +359,12 @@ public:
      * @param Delay Seconds before the tween starts interpolating, after being created
      * @param Loops The number of loops to play. -1 for infinite
      * @param LoopDelay Seconds to pause before starting each loop
-     * @param bYoyo Whether to "yoyo" the tween - once it reaches the end, it starts counting backwards
-     * @param YoyoDelay Seconds to pause before starting to yoyo
+     * @param bPingPong Whether to "pingpong" the tween - once it reaches the end, it starts counting backwards
+     * @param PingPongDelay Seconds to pause before starting to pingpong
      * @param bCanTickDuringPause Whether to play this tween while the game is paused. Useful for UI purposes, such as a pause menu
      */
     UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", AdvancedDisplay = "4"), Category = "Tween")
-    static UNsTweenAsyncActionVector* TweenVector(FVector Start = FVector::ZeroVector, FVector End = FVector::ZeroVector, float DurationSecs = 1.0f, ENsTweenEase EaseType = ENsTweenEase::InOutQuad, float EaseParam1 = 0, float EaseParam2 = 0, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bYoyo = false, float YoyoDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
+    static UNsTweenAsyncActionVector* TweenVector(FVector Start = FVector::ZeroVector, FVector End = FVector::ZeroVector, float DurationSecs = 1.0f, ENsTweenEase EaseType = ENsTweenEase::InOutQuad, float EaseParam1 = 0, float EaseParam2 = 0, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bPingPong = false, float PingPongDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
 
     /**
      * @brief Tween a float parameter between the given values
@@ -375,12 +375,12 @@ public:
      * @param Delay Seconds before the tween starts interpolating, after being created
      * @param Loops The number of loops to play. -1 for infinite
      * @param LoopDelay Seconds to pause before starting each loop
-     * @param bYoyo Whether to "yoyo" the tween - once it reaches the end, it starts counting backwards
-     * @param YoyoDelay Seconds to pause before starting to yoyo
+     * @param bPingPong Whether to "pingpong" the tween - once it reaches the end, it starts counting backwards
+     * @param PingPongDelay Seconds to pause before starting to pingpong
      * @param bCanTickDuringPause Whether to play this tween while the game is paused. Useful for UI purposes, such as a pause menu
      */
     UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", AdvancedDisplay = "4"), Category = "Tween|Custom Curve")
-    static UNsTweenAsyncActionVector* TweenVectorCustomCurve(FVector Start = FVector::ZeroVector, FVector End = FVector::ZeroVector, float DurationSecs = 1.0f, UCurveFloat* Curve = nullptr, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bYoyo = false, float YoyoDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
+    static UNsTweenAsyncActionVector* TweenVectorCustomCurve(FVector Start = FVector::ZeroVector, FVector End = FVector::ZeroVector, float DurationSecs = 1.0f, UCurveFloat* Curve = nullptr, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bPingPong = false, float PingPongDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
 
     //~ Begin UNsTweenAsyncAction Interface
     virtual NsTweenInstance* CreateTween() override;
@@ -421,12 +421,12 @@ public:
      * @param Delay Seconds before the tween starts interpolating, after being created
      * @param Loops The number of loops to play. -1 for infinite
      * @param LoopDelay Seconds to pause before starting each loop
-     * @param bYoyo Whether to "yoyo" the tween - once it reaches the end, it starts counting backwards
-     * @param YoyoDelay Seconds to pause before starting to yoyo
+     * @param bPingPong Whether to "pingpong" the tween - once it reaches the end, it starts counting backwards
+     * @param PingPongDelay Seconds to pause before starting to pingpong
      * @param bCanTickDuringPause Whether to play this tween while the game is paused. Useful for UI purposes, such as a pause menu
      */
     UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", AdvancedDisplay = "4"), Category = "Tween")
-    static UNsTweenAsyncActionVector2D* TweenVector2D(FVector2D Start = FVector2D::ZeroVector, FVector2D End = FVector2D::ZeroVector, float DurationSecs = 1.0f, ENsTweenEase EaseType = ENsTweenEase::InOutQuad, float EaseParam1 = 0, float EaseParam2 = 0, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bYoyo = false, float YoyoDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
+    static UNsTweenAsyncActionVector2D* TweenVector2D(FVector2D Start = FVector2D::ZeroVector, FVector2D End = FVector2D::ZeroVector, float DurationSecs = 1.0f, ENsTweenEase EaseType = ENsTweenEase::InOutQuad, float EaseParam1 = 0, float EaseParam2 = 0, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bPingPong = false, float PingPongDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
 
     /**
      * @brief Tween a float parameter between the given values
@@ -437,12 +437,12 @@ public:
      * @param Delay Seconds before the tween starts interpolating, after being created
      * @param Loops The number of loops to play. -1 for infinite
      * @param LoopDelay Seconds to pause before starting each loop
-     * @param bYoyo Whether to "yoyo" the tween - once it reaches the end, it starts counting backwards
-     * @param YoyoDelay Seconds to pause before starting to yoyo
+     * @param bPingPong Whether to "pingpong" the tween - once it reaches the end, it starts counting backwards
+     * @param PingPongDelay Seconds to pause before starting to pingpong
      * @param bCanTickDuringPause Whether to play this tween while the game is paused. Useful for UI purposes, such as a pause menu
      */
     UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", AdvancedDisplay = "4", DisplayName = "Tween Vector 2D Custom Curve"), Category = "Tween|Custom Curve")
-    static UNsTweenAsyncActionVector2D* TweenVector2DCustomCurve(FVector2D Start = FVector2D::ZeroVector, FVector2D End = FVector2D::ZeroVector, float DurationSecs = 1.0f, UCurveFloat* Curve = nullptr, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bYoyo = false, float YoyoDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
+    static UNsTweenAsyncActionVector2D* TweenVector2DCustomCurve(FVector2D Start = FVector2D::ZeroVector, FVector2D End = FVector2D::ZeroVector, float DurationSecs = 1.0f, UCurveFloat* Curve = nullptr, float Delay = 0, int Loops = 0, float LoopDelay = 0, bool bPingPong = false, float PingPongDelay = 0, bool bCanTickDuringPause = false, bool bUseGlobalTimeDilation = true);
 
     //~ Begin UNsTweenAsyncAction Interface
     virtual NsTweenInstance* CreateTween() override;

--- a/Source/NsTween/Public/Classes/NsTweenInstance.h
+++ b/Source/NsTween/Public/Classes/NsTweenInstance.h
@@ -14,13 +14,13 @@ enum class ENsTweenDelayState : uint8
     None,
     Start,
     Loop,
-    YoYo
+    PingPong
 };
 
 /**
  * Tween Instance
  */
-class NSTWEEN_API NsTweenInstance
+struct NSTWEEN_API NsTweenInstance
 {
 
 // Variables
@@ -47,11 +47,11 @@ public:
     /** Is the tween paused */
     bool bIsPaused;
 
-    /** Should YoYo */
-    bool bShouldYoYo;
+    /** Should PingPong */
+    bool bShouldPingPong;
 
-    /** is the tween playing YoYo */
-    bool bIsPlayingYoYo;
+    /** is the tween playing PingPong */
+    bool bIsPlayingPingPong;
 
     /** Can tick during pause */
     bool bCanTickDuringPause;
@@ -71,8 +71,8 @@ public:
     /** Loop delay seconds */
     float LoopDelaySecs;
 
-    /** YoYo delay seconds */
-    float YoyoDelaySecs;
+    /** PingPong delay seconds */
+    float PingPongDelaySecs;
 
     /** Time multiplier */
     float TimeMultiplier;
@@ -86,10 +86,10 @@ public:
     /** Tween delay state */
     ENsTweenDelayState DelayState;
 
-private:
+public:
 
-    /** Function to run on YoYo */
-    TFunction<void()> OnYoyo;
+    /** Function to run on PingPong */
+    TFunction<void()> OnPingPong;
 
     /** Function to run on Loop */
     TFunction<void()> OnLoop;
@@ -97,7 +97,6 @@ private:
     /** Function to run on Complete */
     TFunction<void()> OnComplete;
 
-public:
 
     /** Constructor */
     NsTweenInstance()
@@ -108,15 +107,15 @@ public:
         , bShouldAutoDestroy(true)
         , bIsActive(true)
         , bIsPaused(false)
-        , bShouldYoYo(false)
-        , bIsPlayingYoYo(false)
+        , bShouldPingPong(false)
+        , bIsPlayingPingPong(false)
         , bCanTickDuringPause(false)
         , bUseGlobalTimeDilation(true)
         , NumLoops(0)
         , NumLoopsCompleted(0)
         , DelaySecs(0)
         , LoopDelaySecs(0)
-        , YoyoDelaySecs(0)
+        , PingPongDelaySecs(0)
         , TimeMultiplier(0)
         , EaseParam1(0)
         , EaseParam2(0)
@@ -129,17 +128,17 @@ public:
     /** Set Delay */
     NsTweenInstance* SetDelay(float InDelaySecs);
 
-    /** How many times to replay the loop (yoyo included). use -1 for infinity */
+    /** How many times to replay the loop (pingpong included). use -1 for infinity */
     NsTweenInstance* SetLoops(int InNumLoops);
 
     /** Seconds to wait before starting another loop */
     NsTweenInstance* SetLoopDelay(float InLoopDelaySecs);
 
     /** Interpolate backwards after reaching the end */
-    NsTweenInstance* SetYoyo(bool bInShouldYoyo);
+    NsTweenInstance* SetPingPong(bool bInShouldPingPong);
 
-    /** Seconds to wait before yoyo-ing backwards */
-    NsTweenInstance* SetYoyoDelay(float InYoyoDelaySecs);
+    /** Seconds to wait before pingpong-ing backwards */
+    NsTweenInstance* SetPingPongDelay(float InPingPongDelaySecs);
 
     /** Multiply the time delta by this number to speed up or slow down the tween. Only positive numbers allowed */
     NsTweenInstance* SetTimeMultiplier(float InTimeMultiplier);
@@ -159,8 +158,8 @@ public:
     /** Automatically recycles this instance after tween is complete (Stop() is called)*/
     NsTweenInstance* SetAutoDestroy(bool bInShouldAutoDestroy);
 
-    /** Callback on YoYo */
-    NsTweenInstance* SetOnYoyo(TFunction<void()> Handler);
+    /** Callback on PingPong */
+    NsTweenInstance* SetOnPingPong(TFunction<void()> Handler);
 
     /** Callback on Loop */
     NsTweenInstance* SetOnLoop(TFunction<void()> Handler);
@@ -205,14 +204,14 @@ private:
     /** Start New Loop */
     void StartNewLoop();
 
-    /** Start YoYo */
-    void StartYoyo();
+    /** Start PingPong */
+    void StartPingPong();
 };
 
 /**
  * Tween Instance - Float
  */
-class NSTWEEN_API NsTweenInstanceFloat : public NsTweenInstance
+struct NSTWEEN_API NsTweenInstanceFloat : public NsTweenInstance
 {
 // Functions
 public:
@@ -240,7 +239,7 @@ public:
 /**
  * Tween Instance - Quat
  */
-class NSTWEEN_API NsTweenInstanceQuat : public NsTweenInstance
+struct NSTWEEN_API NsTweenInstanceQuat : public NsTweenInstance
 {
 // Functions
 public:
@@ -268,7 +267,7 @@ public:
 /**
  * Tween Instance - Vector
  */
-class NSTWEEN_API NsTweenInstanceVector : public NsTweenInstance
+struct NSTWEEN_API NsTweenInstanceVector : public NsTweenInstance
 {
 // Functions
 public:
@@ -296,7 +295,7 @@ public:
 /**
  * Tween Instance - Vector2D
  */
-class NSTWEEN_API NsTweenInstanceVector2D : public NsTweenInstance
+struct NSTWEEN_API NsTweenInstanceVector2D : public NsTweenInstance
 {
 // Functions
 public:
@@ -324,7 +323,7 @@ public:
 /**
  * Tween Instance - Rotator
  */
-class NSTWEEN_API NsTweenInstanceRotator : public NsTweenInstance
+struct NSTWEEN_API NsTweenInstanceRotator : public NsTweenInstance
 {
 // Functions
 public:

--- a/Source/NsTween/Public/Classes/NsTweenUObject.h
+++ b/Source/NsTween/Public/Classes/NsTweenUObject.h
@@ -5,7 +5,8 @@
 #include "NsTweenUObject.generated.h"
 
 /**
- * Use this to wrap an NsTweenInstance inside a UObject, so that it's destroyed when its outer object is destroyed
+ * Simple UObject wrapper around a NsTweenInstance.
+ * Ensures the tween is cleaned up when this UObject is destroyed.
  */
 UCLASS()
 class UNsTweenUObject : public UObject
@@ -22,15 +23,15 @@ public:
     virtual void BeginDestroy() override;
     //~ End UObject Interface
 
-    /** Stop the tween immediately and mark this object for destruction */
+    /** Assign the tween instance to manage. */
     void SetTweenInstance(class NsTweenInstance* const InTween);
 
-    /** Stop the tween immediately and mark this object for destruction */
+    /** Stop the tween immediately and mark this UObject for destruction */
     void Destroy();
 
 // Variables
 public:
 
-    /** Instance */
+    /** Managed tween instance */
     class NsTweenInstance* Tween;
 };


### PR DESCRIPTION
## Summary
- refactor `NsTweenUObject` for cleaner lifecycle management
- convert tween instance classes to structs
- replace all YoYo references with PingPong
- update blueprint API and comments to use new naming