### PR TITLE
Add tween debug logging

### DIFF
--- a/Source/NsTween/Private/Classes/NsTweenCore.cpp
+++ b/Source/NsTween/Private/Classes/NsTweenCore.cpp
@@ -4,6 +4,7 @@
 #include "Classes/NsTweenManager.h"
 #include "Classes/NsTweenSettings.h"
 #include "NsTweenEasing.h"
+#include "DrawDebugHelpers.h"
 
 DEFINE_LOG_CATEGORY(LogNsTween)
 
@@ -101,4 +102,39 @@ FNsTweenInstanceVector2D& NsTweenCore::Play(const FVector2D Start, const FVector
 FNsTweenInstanceQuat& NsTweenCore::Play(const FQuat& Start, const FQuat& End, const float DurationSecs, const ENsTweenEase EaseType, TFunction<void(FQuat)> OnUpdate)
 {
     return *PlayInternal(QuatTweenManager, Start, End, DurationSecs, EaseType, MoveTemp(OnUpdate));
+}
+
+void NsTweenCore::LogActiveTweens()
+{
+    ForEachManager([](auto* Manager)
+    {
+        for (const auto* Tween : Manager->GetActiveTweens())
+        {
+            UE_LOG(LogNsTween, Log, TEXT("%s"), *Tween->ToDebugString());
+        }
+    });
+}
+
+void NsTweenCore::DrawActiveTweens(UWorld* World)
+{
+    if (!World)
+    {
+        return;
+    }
+    ForEachManager([World](auto* Manager)
+    {
+        for (const auto* Tween : Manager->GetActiveTweens())
+        {
+            if (AActor* DebugActor = Tween->GetDebugActor())
+            {
+                DrawDebugString(World,
+                                 DebugActor->GetActorLocation() + FVector(0, 0, 100.f),
+                                 Tween->ToDebugString(),
+                                 DebugActor,
+                                 FColor::White,
+                                 0.f,
+                                 true);
+            }
+        }
+    });
 }

--- a/Source/NsTween/Private/Classes/NsTweenSubsystem.cpp
+++ b/Source/NsTween/Private/Classes/NsTweenSubsystem.cpp
@@ -2,6 +2,13 @@
 
 #include "Classes/NsTweenSubsystem.h"
 #include "Classes/NsTweenCore.h"
+#include "HAL/IConsoleManager.h"
+
+static TAutoConsoleVariable<int32> CVarNsTweenDebugDraw(
+    TEXT("NsTween.DebugDraw"),
+    0,
+    TEXT("Draw debug info for active tweens each tick (0 = off, 1 = on)"),
+    ECVF_Default);
 
 void UNsTweenSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
@@ -45,6 +52,10 @@ void UNsTweenSubsystem::Tick(float DeltaTime)
 #else
             NsTweenCore::Update(GetWorld()->DeltaRealTimeSeconds, GetWorld()->DeltaTimeSeconds, GetWorld()->IsPaused());
 #endif
+            if (CVarNsTweenDebugDraw.GetValueOnGameThread() != 0)
+            {
+                NsTweenCore::DrawActiveTweens(GetWorld());
+            }
         }
     }
 }

--- a/Source/NsTween/Private/Library/NsTweenFunctionLibrary.cpp
+++ b/Source/NsTween/Private/Library/NsTweenFunctionLibrary.cpp
@@ -2,6 +2,8 @@
 
 #include "Library/NsTweenFunctionLibrary.h"
 #include "Classes/NsTweenCore.h"
+#include "Engine/World.h"
+#include "Engine/Engine.h"
 
 float UNsTweenFunctionLibrary::Ease(float t, ENsTweenEase EaseType)
 
@@ -17,4 +19,19 @@ float UNsTweenFunctionLibrary::EaseWithParams(float t, ENsTweenEase EaseType, fl
 void UNsTweenFunctionLibrary::EnsureTweenCapacity(int NumFloatTweens, int NumVectorTweens, int NumVector2DTweens, int NumQuatTweens)
 {
     NsTweenCore::EnsureCapacity(NumFloatTweens, NumVectorTweens, NumVector2DTweens, NumQuatTweens);
+}
+
+void UNsTweenFunctionLibrary::LogActiveTweens()
+{
+    NsTweenCore::LogActiveTweens();
+}
+
+void UNsTweenFunctionLibrary::DrawActiveTweens(UObject* WorldContextObject)
+{
+    if (!WorldContextObject)
+    {
+        return;
+    }
+    UWorld* World = GEngine ? GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::ReturnNull) : nullptr;
+    NsTweenCore::DrawActiveTweens(World);
 }

--- a/Source/NsTween/Private/Library/NsTweenTypeLibrary.cpp
+++ b/Source/NsTween/Private/Library/NsTweenTypeLibrary.cpp
@@ -440,3 +440,15 @@ float FNsTweenInstance::GetEaseParam2() const
 {
     return EaseParam2;
 }
+
+FString FNsTweenInstance::ToDebugString() const
+{
+    const FString EaseName = StaticEnum<ENsTweenEase>()->GetNameStringByValue(static_cast<int64>(EaseType));
+    return FString::Printf(TEXT("%s | Ease: %s | Duration: %.2f | Time: %.2f | Loops: %d/%d"),
+                           *GetValueDebugString(),
+                           *EaseName,
+                           DurationSecs,
+                           Counter,
+                           NumLoopsCompleted,
+                           NumLoops);
+}

--- a/Source/NsTween/Public/Classes/NsTweenCore.h
+++ b/Source/NsTween/Public/Classes/NsTweenCore.h
@@ -39,6 +39,12 @@ public:
     /** Convenience function for UNsTweenEasing::Ease() */
     static float Ease(float T, ENsTweenEase EaseType);
 
+    /** Log debug information for all active tweens */
+    static void LogActiveTweens();
+
+    /** Draw debug information on screen near each tween's debug actor */
+    static void DrawActiveTweens(UWorld* World);
+
     /** Play Tween - Float */
     static FNsTweenInstanceFloat& Play(float Start, float End, float DurationSecs, ENsTweenEase EaseType, TFunction<void(float)> OnUpdate);
 

--- a/Source/NsTween/Public/Classes/NsTweenManager.h
+++ b/Source/NsTween/Public/Classes/NsTweenManager.h
@@ -97,6 +97,11 @@ public:
         return NewTween;
     }
 
+    const TArray<T*>& GetActiveTweens() const
+    {
+        return ActiveTweens;
+    }
+
 private:
     T* GetNewTween()
     {

--- a/Source/NsTween/Public/Library/NsTweenFunctionLibrary.h
+++ b/Source/NsTween/Public/Library/NsTweenFunctionLibrary.h
@@ -37,4 +37,12 @@ public:
     /** Make sure there are at least these many of each type of tween available in memory. Call this only once, probably in a GameInstance blueprint, if you need more initial memory reserved on game startup. */
     UFUNCTION(BlueprintCallable, Category = "Tween|Utility")
     static void EnsureTweenCapacity(int NumFloatTweens = 75, int NumVectorTweens = 50, int NumVector2DTweens = 50, int NumQuatTweens = 10);
+
+    /** Log information about all active tweens to the output log */
+    UFUNCTION(BlueprintCallable, Category = "Tween|Debug")
+    static void LogActiveTweens();
+
+    /** Draw debug information for active tweens near their debug actors */
+    UFUNCTION(BlueprintCallable, Category = "Tween|Debug", meta = (WorldContext = "WorldContextObject"))
+    static void DrawActiveTweens(UObject* WorldContextObject);
 };

--- a/Source/NsTween/Public/Library/NsTweenTypeLibrary.h
+++ b/Source/NsTween/Public/Library/NsTweenTypeLibrary.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
 
 /**
  * Enum used to represent the Ease type
@@ -137,6 +138,9 @@ private:
     /** Function to run on Complete */
     TFunction<void()> OnCompleteCallback;
 
+    /** Actor used for debug drawing */
+    TWeakObjectPtr<AActor> DebugActor;
+
 // Functions
 public:
 
@@ -221,6 +225,16 @@ public:
     /** Get easing parameter two */
     float GetEaseParam2() const;
 
+    /** Set actor for debug drawing */
+    FNsTweenInstance& SetDebugActor(AActor* InActor)
+    {
+        DebugActor = InActor;
+        return *this;
+    }
+
+    /** Get the debug actor */
+    AActor* GetDebugActor() const { return DebugActor.Get(); }
+
 
     /** Constructor */
     FNsTweenInstance()
@@ -244,6 +258,7 @@ public:
         , EaseParam1(0)
         , EaseParam2(0)
         , DelayState()
+        , DebugActor(nullptr)
     {}
 
     /** Destructor */
@@ -271,7 +286,13 @@ public:
     /** Update  */
     void Update(float UnscaledDeltaSeconds, float DilatedDeltaSeconds, bool bIsGamePaused = false);
 
+    /** Return a debug string describing this tween */
+    virtual FString ToDebugString() const;
+
 protected:
+
+    /** Return debug info for the value type (Start/End) */
+    virtual FString GetValueDebugString() const { return FString(); }
 
     /** Apply Easing */
     virtual void ApplyEasing(float EasedPercent) = 0;
@@ -301,6 +322,10 @@ public:
 
     //~ Begin NsTweenInstance Interface
     virtual void ApplyEasing(float EasedPercent) override;
+    virtual FString GetValueDebugString() const override
+    {
+        return FString::Printf(TEXT("Start: %f End: %f"), StartValue, EndValue);
+    }
     //~ End NsTweenInstance Interface
 
 // Variables
@@ -329,6 +354,10 @@ public:
 
     //~ Begin NsTweenInstance Interface
     virtual void ApplyEasing(float EasedPercent) override;
+    virtual FString GetValueDebugString() const override
+    {
+        return FString::Printf(TEXT("Start: %s End: %s"), *StartValue.ToString(), *EndValue.ToString());
+    }
     //~ End NsTweenInstance Interface
 
 // Variables
@@ -357,6 +386,10 @@ public:
 
     //~ Begin NsTweenInstance Interface
     virtual void ApplyEasing(float EasedPercent) override;
+    virtual FString GetValueDebugString() const override
+    {
+        return FString::Printf(TEXT("Start: %s End: %s"), *StartValue.ToString(), *EndValue.ToString());
+    }
     //~ End NsTweenInstance Interface
 
 // Variables
@@ -385,6 +418,10 @@ public:
 
     //~ Begin NsTweenInstance Interface
     virtual void ApplyEasing(float EasedPercent) override;
+    virtual FString GetValueDebugString() const override
+    {
+        return FString::Printf(TEXT("Start: %s End: %s"), *StartValue.ToString(), *EndValue.ToString());
+    }
     //~ End NsTweenInstance Interface
 
 // Variables
@@ -413,6 +450,10 @@ public:
 
     //~ Begin NsTweenInstance Interface
     virtual void ApplyEasing(float EasedPercent) override;
+    virtual FString GetValueDebugString() const override
+    {
+        return FString::Printf(TEXT("Start: %s End: %s"), *StartValue.ToString(), *EndValue.ToString());
+    }
     //~ End NsTweenInstance Interface
 
 // Variables


### PR DESCRIPTION
## Summary
- expose active tweens from `NsTweenManager`
- add `ToDebugString` helper for tweens and implement per-type value info
- implement `LogActiveTweens` in `NsTweenCore`
- provide Blueprint callable wrapper in `NsTweenFunctionLibrary`
- add drawing of debug data near an actor using `DrawDebugString`