### PR TITLE
Add owner lifetime guard for tweens

### DIFF
--- a/Source/NsTween/Private/NsTween.cpp
+++ b/Source/NsTween/Private/NsTween.cpp
@@ -42,6 +42,14 @@ bool FNsTween::Tick(float DeltaSeconds)
         return bActive;
     }
 
+    if (Spec.bEnforceOwnerLifetime && !Spec.Owner.IsValid())
+    {
+        bActive = false;
+        Strategy.Reset();
+        Easing.Reset();
+        return false;
+    }
+
     // Lazily initialize the strategy the first time we tick so creation happens on the game thread.
     if (!bInitialized)
     {

--- a/Source/NsTween/Private/NsTweenBuilder.cpp
+++ b/Source/NsTween/Private/NsTweenBuilder.cpp
@@ -13,6 +13,10 @@ FNsTweenBuilder::FNsTweenBuilder(FNsTweenSpec&& InSpec, TFunction<TSharedPtr<ITw
 {
     bLooping = (Spec.WrapMode == ENsTweenWrapMode::Loop) || (Spec.LoopCount != 0);
     bPingPong = (Spec.WrapMode == ENsTweenWrapMode::PingPong);
+    if (Spec.Owner.IsValid())
+    {
+        Spec.bEnforceOwnerLifetime = true;
+    }
     UpdateWrapMode();
 }
 
@@ -151,6 +155,19 @@ FNsTweenBuilder& FNsTweenBuilder::SetCurveAsset(UCurveFloat* Curve)
         {
             Spec.EasingPreset = ENsTweenEase::CurveAsset;
         }
+    }
+
+    return *this;
+}
+
+FNsTweenBuilder& FNsTweenBuilder::SetOwner(UObject* InOwner)
+{
+    NSTWEEN_SCOPE_CYCLE_COUNTER("NsTweenBuilder::SetOwner");
+
+    if (CanConfigure())
+    {
+        Spec.Owner = InOwner;
+        Spec.bEnforceOwnerLifetime = (InOwner != nullptr);
     }
 
     return *this;

--- a/Source/NsTween/Public/NsTweenBuilder.h
+++ b/Source/NsTween/Public/NsTweenBuilder.h
@@ -48,6 +48,9 @@ public:
     /** Specifies the curve asset used for easing evaluation. */
     FNsTweenBuilder& SetCurveAsset(UCurveFloat* Curve);
 
+    /** Associates the tween with an owning UObject to gate its lifetime. */
+    FNsTweenBuilder& SetOwner(UObject* InOwner);
+
     /** Registers a callback executed when the tween completes. */
     FNsTweenBuilder& OnComplete(TFunction<void()> Callback);
 

--- a/Source/NsTween/Public/NsTweenTypeLibrary.h
+++ b/Source/NsTween/Public/NsTweenTypeLibrary.h
@@ -6,6 +6,7 @@
 #include "Interfaces/ITweenValue.h"
 #include "Kismet/BlueprintFunctionLibrary.h"
 #include "Curves/CurveFloat.h"
+#include "UObject/WeakObjectPtr.h"
 #include "NsTweenTypeLibrary.generated.h"
 
 /** Delegate fired every tick of a tween with the normalized alpha. */
@@ -140,8 +141,15 @@ public:
     /** Callback executed when the tween ping-pongs. */
     FNsTweenOnPingPong OnPingPong;
 
+    /** Weak reference to an owning object whose lifetime gates the tween. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Tween")
+    TWeakObjectPtr<UObject> Owner = nullptr;
+
     /** Pointer for user-defined context data. */
     void* UserData = nullptr;
+
+    /** Internal flag set when the owner lifetime should be enforced. */
+    bool bEnforceOwnerLifetime = false;
 };
 
 /** A single entry within a tween sequence asset. */


### PR DESCRIPTION
## Summary
- allow tweens to carry a weak owning UObject reference
- expose a builder helper for assigning the owner while configuring tweens
- stop ticking tweens once the owner becomes invalid to avoid stale callbacks